### PR TITLE
Automaticaly change object when call reset with gazebo ros service

### DIFF
--- a/multiworld/core/image_env.py
+++ b/multiworld/core/image_env.py
@@ -161,19 +161,13 @@ class ImageEnv(ProxyEnv, MultitaskEnv):
         if self.wrapped_env.__class__.__name__ == 'SawyerPushXYEnv':
             # TUNG: Reset object to reset position again (after moved to goal position)
             if self.pause_on_reset:
-                if self.wrapped_env.use_gazebo_auto:
-                    print(bcolors.OKBLUE + 'move object to original reset position and press enter'
+                if self.wrapped_env.AUTO_MOVE_OBJ:
+                    print(bcolors.OKGREEN + 'Auto move object to original reset position'
                           + bcolors.ENDC)
-                    args = dict(x=self.wrapped_env.pos_object_reset_position[0],
-                                y=self.wrapped_env.pos_object_reset_position[1],
-                                z=self.wrapped_env.pos_object_reset_position[2])
-                    msg = dict(func='set_object_los', args=args)
-                    self.wrapped_env.client.sending(msg,
-                                                    sleep_before=self.config.SLEEP_BEFORE_SENDING_CMD_SOCKET,
-                                                    sleep_after=self.config.SLEEP_BETWEEN_2_CMDS)
-                    self.wrapped_env.client.sending(msg,
-                                                    sleep_before=0,
-                                                    sleep_after=self.config.SLEEP_AFTER_SENDING_CMD_SOCKET)
+                    x=self.wrapped_env.pos_object_reset_position[0]
+                    y=self.wrapped_env.pos_object_reset_position[1]
+                    z=self.wrapped_env.pos_object_reset_position[2]
+                    self.wrapped_env.set_obj_to_pos('cylinder',[x,y,z])    
                 else:
                     input(bcolors.OKBLUE + 'move object to original reset position and press enter'
                           + bcolors.ENDC)

--- a/multiworld/envs/real_world/sawyer/sawyer_pushing.py
+++ b/multiworld/envs/real_world/sawyer/sawyer_pushing.py
@@ -3,6 +3,13 @@ import sawyer_control.envs.sawyer_pushing as sawyer_pushing
 from multiworld.core.serializable import Serializable
 from multiworld.core.multitask_env import MultitaskEnv
 import time
+import rospy 
+import rospkg 
+from gazebo_msgs.msg import ModelState 
+from gazebo_msgs.srv import SetModelState
+import numpy as np
+## http://gazebosim.org/tutorials/?tut=ros_comm
+## http://answers.gazebosim.org/question/22125/how-to-set-a-models-position-using-gazeboset_model_state-service-in-python/
 
 
 class bcolors:
@@ -19,6 +26,8 @@ class bcolors:
 class SawyerPushXYEnv(sawyer_pushing.SawyerPushXYEnv, MultitaskEnv):
     ''' Must Wrap with Image Env to use!'''
 
+    AUTO_MOVE_OBJ = True
+
     def __init__(self,
                  **kwargs
                  ):
@@ -32,6 +41,25 @@ class SawyerPushXYEnv(sawyer_pushing.SawyerPushXYEnv, MultitaskEnv):
             ('state_desired_goal', self.goal_space),
             ('state_achieved_goal', self.goal_space),
         ])
+
+
+    def set_obj_to_pos(self,name, pos):
+        #rospy.init_node('set_pose')
+        state_msg = ModelState()
+        state_msg.model_name = name
+        state_msg.pose.position.x = float(pos[0])
+        state_msg.pose.position.y = float(pos[1])
+        state_msg.pose.position.z = float(pos[2])
+        state_msg.pose.orientation.x = 0.0 #pos[3]
+        state_msg.pose.orientation.y = 1.0 #pos[4]
+        state_msg.pose.orientation.z = 0.0 #pos[5]
+        state_msg.pose.orientation.w = 0.0 #pos[6]
+        rospy.wait_for_service('/gazebo/set_model_state')
+        try:
+            set_state = rospy.ServiceProxy('/gazebo/set_model_state', SetModelState)
+            resp = set_state( state_msg )
+        except rospy.ServiceException as e:
+            print("Service call failed: %s" % e)
 
     def step(self, action):
         self._act(action)
@@ -65,18 +93,13 @@ class SawyerPushXYEnv(sawyer_pushing.SawyerPushXYEnv, MultitaskEnv):
         else:
             self._reset_robot()
         if self.pause_on_reset:
-            if self.use_gazebo_auto:
-                print(bcolors.OKBLUE+'move object to reset position and press enter'+bcolors.ENDC)
-                args = dict(x=self.pos_object_reset_position[0],
-                            y=self.pos_object_reset_position[1],
-                            z=self.pos_object_reset_position[2])
-                msg = dict(func='set_object_los', args=args)
-                self.client.sending(msg, sleep_before=self.config.SLEEP_BEFORE_SENDING_CMD_SOCKET,
-                                    sleep_after=self.config.SLEEP_BETWEEN_2_CMDS)
-                self.client.sending(msg, sleep_before=0,
-                                    sleep_after=self.config.SLEEP_AFTER_SENDING_CMD_SOCKET)
+            if self.AUTO_MOVE_OBJ:
+                print(bcolors.OKGREEN+'Auto move object to reset position'+bcolors.ENDC)
+                pos = list([self.pos_object_reset_position[0],self.pos_object_reset_position[1],self.pos_object_reset_position[2]])
+                self.set_obj_to_pos('cylinder',pos)
+                
             else:
-                input(bcolors.OKBLUE+'move object to reset position and press enter'+bcolors.ENDC)
+                input(bcolors.OKBLUE+'Move object to reset position and press enter'+bcolors.ENDC)
         goal = self.sample_goal()
         self._state_goal = goal['state_desired_goal']
         return self._get_obs()
@@ -103,7 +126,21 @@ class SawyerPushXYEnv(sawyer_pushing.SawyerPushXYEnv, MultitaskEnv):
 
     def set_to_goal(self, goal):
         goal = goal['state_desired_goal']
-        super().set_to_goal(goal)
+        obj_goal = np.concatenate((goal[:2], [self.z]))
+        ee_goal = np.concatenate((goal[2:4], [self.z]))
+        if self.AUTO_MOVE_OBJ:
+            print(bcolors.OKGREEN + 'Auto place object at end effector location' +
+                  bcolors.ENDC)
+            # TUNG: +- 0.05 to avoid collision since object right below gripper
+            x=goal[0] + 0.05
+            y=goal[1] - 0.05
+            z=self.pos_object_reset_position[2]
+            self.set_obj_to_pos('cylinder',[x,y,z])
+
+        else:
+            input(bcolors.OKBLUE + 'Place object at end effector location and press enter' +
+                  bcolors.ENDC)
+        self._position_act(ee_goal - self._get_endeffector_pose()[:3])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Use ros service supported by Gazebo to change Cylinder object stead of call external script.